### PR TITLE
Sync with version 13.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "postcss-reporter": "^6.0.1",
     "string-width": "^4.2.0",
     "table": "^5.4.6"
+  },
+  "peerDependencies": {
+    "stylelint": "^13.3.1"
   }
 }

--- a/stringFormatter.js
+++ b/stringFormatter.js
@@ -1,5 +1,5 @@
 /**
- * https://github.com/stylelint/stylelint/blob/c9741e1e6dd01c987bd8f139c8359984dc4340f4/lib/formatters/stringFormatter.js
+ * https://github.com/stylelint/stylelint/blob/845c373e464f3ccd3f00638a8c1aa55e9a354294/lib/formatters/stringFormatter.js
  */
 'use strict';
 
@@ -107,6 +107,7 @@ function formatter(messages, source) {
 
 	const orderedMessages = _.sortBy(
 		messages,
+		// eslint-disable-next-line no-confusing-arrow
 		(m) => (m.line ? 2 : 1), // positionless first
 		(m) => m.line,
 		(m) => m.column,
@@ -202,7 +203,7 @@ function formatter(messages, source) {
  * @param {import('stylelint').StylelintResult[]} results
  * @returns {string}
  */
-module.exports = function(results) {
+module.exports = function (results) {
 	let output = invalidOptionsFormatter(results);
 
 	output += deprecationsFormatter(results);

--- a/verboseFormatter.js
+++ b/verboseFormatter.js
@@ -1,5 +1,5 @@
 /**
- * https://github.com/stylelint/stylelint/blob/c9741e1e6dd01c987bd8f139c8359984dc4340f4/lib/formatters/verboseFormatter.js
+ * https://github.com/stylelint/stylelint/blob/845c373e464f3ccd3f00638a8c1aa55e9a354294/lib/formatters/verboseFormatter.js
  */
 'use strict';
 
@@ -11,7 +11,7 @@ const stringFormatter = require('./stringFormatter');
  * @param {import('stylelint').StylelintResult[]} results
  * @returns {string}
  */
-module.exports = function(results) {
+module.exports = function (results) {
 	let output = stringFormatter(results);
 
 	if (output === '') {


### PR DESCRIPTION
This update also includes bumping `chalk` to `4.0.0` which was done in #6.