### PR TITLE
Bump softprops/action-gh-release from 0.1.13 to 0.1.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ steps.tag_name.outputs.current_version }}
 
-      - uses: softprops/action-gh-release@v0.1.13
+      - uses: softprops/action-gh-release@v0.1.14
         with:
           body: ${{ steps.changelog_reader.outputs.changes }}
 


### PR DESCRIPTION
Correct version of #78.

ref: https://github.com/softprops/action-gh-release/issues/192