### PR TITLE
Fix usage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 - Synced code with [stylelint 16.0.0](https://github.com/stylelint/stylelint/releases/tag/16.0.0)
 - Migrated to ESM and changed `.js` extensions to `.mjs`
+    - Loading the string formatter: `--custom-formatter=stylelint-actions-formatters`
+    - Loading the verbose formatter: `--custom-formatter=stylelint-actions-formatters/src/verboseFormatter.mjs`
 
 ## [15.11.0](https://github.com/xt0rted/stylelint-actions-formatters/compare/v15.10.3...v15.11.0) - 2023-12-28
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ It also has a peer dependency on that version.
 ### String formatter
 
 ```console
- stylelint "scss/**/*.scss" --custom-formatter=node_modules/stylelint-actions-formatters
+ stylelint "scss/**/*.scss" --custom-formatter=stylelint-actions-formatters
 ```
 
 ### Verbose formatter
 
 ```console
- stylelint "scss/**/*.scss" --custom-formatter=node_modules/stylelint-actions-formatters/src/verboseFormatter.mjs
+ stylelint "scss/**/*.scss" --custom-formatter=stylelint-actions-formatters/src/verboseFormatter.mjs
 ```
 
 > Note: If you're not running on GitHub Actions then these reporters will function the same as the ones that ship with Stylelint.


### PR DESCRIPTION
Now that everything is esm the old way of loading a custom formatter doesn't work, this is the correct way to do it.